### PR TITLE
Update Dockerfile

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,6 @@ jobs:
           command: |
             set -u
             TAG=0.1.$CIRCLE_BUILD_NUM
-            yarn install --immutable
             docker-compose -f docker-compose.$BUILD_ARCH build
 workflows:
   cleanup:

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -10,9 +10,10 @@ COPY package.json yarn.lock ./
 RUN corepack enable \
     && corepack prepare yarn@stable --activate \
     && yarn install --immutable \
-    && yarn cache clean \
-    && mkdir -p node_modules \
-    && cp -fR /usr/local/lib/node_modules/* node_modules/.
+    && yarn cache clean
+
+# Add modules to the image files
+COPY node_modules/ node_modules
 
 # Stage 2: Build PHP and Apache environment
 FROM php:7.4.33-alpine3.15
@@ -22,7 +23,7 @@ ARG HTDOCS
 ENV HTDOCS=${HTDOCS:-"/usr/local/apache2/htdocs"}
 WORKDIR ${HTDOCS}
 
-COPY --from=node-build /usr/local/project/node_modules/ node_modules
+COPY --from=node-build node_modules/ node_modules
 # END - Multi-stage Build
 
 # Install base packages

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -10,9 +10,10 @@ COPY package.json yarn.lock ./
 RUN corepack enable \
     && corepack prepare yarn@stable --activate \
     && yarn install --immutable \
-    && yarn cache clean \
-    && mkdir -p node_modules \
-    && cp -fR /usr/local/lib/node_modules/* node_modules/.
+    && yarn cache clean
+
+# Add modules to the image files
+COPY node_modules/ node_modules
 
 # Stage 2: Build PHP and Apache environment
 FROM php:7.4.33-alpine3.15
@@ -22,7 +23,7 @@ ARG HTDOCS
 ENV HTDOCS=${HTDOCS:-"/usr/local/apache2/htdocs"}
 WORKDIR ${HTDOCS}
 
-COPY --from=node-build /usr/local/project/node_modules/ node_modules
+COPY --from=node-build node_modules/ node_modules
 # END - Multi-stage Build
 
 # Install base packages

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,9 +10,10 @@ COPY package.json yarn.lock ./
 RUN corepack enable \
     && corepack prepare yarn@stable --activate \
     && yarn install --immutable \
-    && yarn cache clean \
-    && mkdir -p node_modules \
-    && cp -fR /usr/local/lib/node_modules/* node_modules/.
+    && yarn cache clean
+
+# Add modules to the image files
+COPY node_modules/ node_modules
 
 # Stage 2: Build PHP and Apache environment
 FROM php:7.4.33-alpine3.15
@@ -22,7 +23,7 @@ ARG HTDOCS
 ENV HTDOCS=${HTDOCS:-"/usr/local/apache2/htdocs"}
 WORKDIR ${HTDOCS}
 
-COPY --from=node-build /usr/local/project/node_modules/ node_modules
+COPY --from=node-build node_modules/ node_modules
 # END - Multi-stage Build
 
 # Install base packages

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -12,9 +12,6 @@ RUN corepack enable \
     && yarn install --immutable \
     && yarn cache clean
 
-# Add modules to the image files
-COPY node_modules/ node_modules
-
 # Stage 2: Build PHP and Apache environment
 FROM php:7.4.33-alpine3.15
 

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -10,9 +10,10 @@ COPY package.json yarn.lock ./
 RUN corepack enable \
     && corepack prepare yarn@stable --activate \
     && yarn install --immutable \
-    && yarn cache clean \
-    && mkdir -p node_modules \
-    && cp -fR /usr/local/lib/node_modules/* node_modules/.
+    && yarn cache clean
+
+# Add modules to the image files
+COPY node_modules/ node_modules
 
 # Stage 2: Build PHP and Apache environment
 FROM php:7.4.33-alpine3.15
@@ -22,7 +23,7 @@ ARG HTDOCS
 ENV HTDOCS=${HTDOCS:-"/usr/local/apache2/htdocs"}
 WORKDIR ${HTDOCS}
 
-COPY --from=node-build /usr/local/project/node_modules/ node_modules
+COPY --from=node-build node_modules/ node_modules
 # END - Multi-stage Build
 
 # Install base packages

--- a/Dockerfile.x86_64
+++ b/Dockerfile.x86_64
@@ -20,7 +20,7 @@ ARG HTDOCS
 ENV HTDOCS=${HTDOCS:-"/usr/local/apache2/htdocs"}
 WORKDIR ${HTDOCS}
 
-COPY --from=node-build node_modules/ node_modules
+COPY --from=node-build /usr/local/project/node_modules/ node_modules
 # END - Multi-stage Build
 
 # Install base packages


### PR DESCRIPTION
Build stage context fix

The Docker COPY command is used in a Dockerfile to copy files and directories from the host machine into a Docker image during the build process. Its syntax is COPY <source> <destination>, where <source> is the path on the host and <destination> is the path inside the Docker image.